### PR TITLE
support specifying an ARN instead of creating one

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,10 @@ Plugin which auto-subscribes a log delivery lambda function to lambda log groups
 custom:
     shipLogs:
         # Required
+        arn: existing cloudwatch logs ARN
+        # OR
         collectorUrl: Paste your url from step 1. here
+
         # Optional, default pattern is "[timestamp=*Z, request_id=\"*-*\", event]"
         filterPattern: "[timestamp=*Z, request_id=\"*-*\", correlation_id=\"*-*\", event]"
 ```
@@ -22,14 +25,15 @@ This plugin automates the process described in the [readme](https://github.com/S
 
 Upon running `sls deploy` it will...
 
-1. Create a temporary function in the root of your serverless project
-2. Add that function to the in-memory CloudFormation script created by the serverless framework
+1. if no existing cloudwatch function is specified
+    1. Create a temporary function in the root of your serverless project
+    2. Add that function to the in-memory CloudFormation script created by the serverless framework
 3. Iterate through all the functions (except for the sumologic one) and generate:
     1. CloudFormation Subscription Filter resources linking the log groups created by serverless framework to the sumologic lambda function.
 4. Wait for the stack creation/update to complete and then delete the temporarily created function source directory.
 
 # Caveats
-You must be running serverless 1.1.0 or higher and have the following configuration in your `serverless.yml` 
+You must be running serverless 1.1.0 or higher and have the following configuration in your `serverless.yml`
 to ensure that the log groups exist and are managed by the same CloudFormation script.
 ```yaml
 provider:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-plugin-cloudwatch-sumologic",
-  "version": "0.0.8",
+  "version": "0.0.9-alpha.0",
   "description": "Serverless Plugin to enable log delivery from cloudwatch to sumologic via a lambda function and log group subscriptions",
   "main": "src/index.js",
   "repository": {


### PR DESCRIPTION
I meant to create this PR against our fork directly, but regardless, I would submit it here eventually as well.

Instead of creating a new function per stack, support specifying an existing function ARN as the cloudwatch consumer.  