### PR TITLE
Bump serverless version, remove cfLogs requirement, add ability to specify role ARN.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ custom:
 
         # Optional, default pattern is "[timestamp=*Z, request_id=\"*-*\", event]"
         filterPattern: "[timestamp=*Z, request_id=\"*-*\", correlation_id=\"*-*\", event]"
+        role: ARN of IAM role to use
 ```
 
 # How it works
@@ -33,12 +34,7 @@ Upon running `sls deploy` it will...
 4. Wait for the stack creation/update to complete and then delete the temporarily created function source directory.
 
 # Caveats
-You must be running serverless 1.1.0 or higher and have the following configuration in your `serverless.yml`
-to ensure that the log groups exist and are managed by the same CloudFormation script.
-```yaml
-provider:
-    cfLogs: true
-```
+You must be running serverless 1.6.0 or higher.
 
 # Contribute
 Please fork this repo to make changes and then issue a pull request back to this repo.

--- a/package.json
+++ b/package.json
@@ -13,6 +13,6 @@
     "lodash": "^4.16.4"
   },
   "peerDependencies": {
-    "serverless": "^1.1.0"
+    "serverless": "^1.6.0"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -22,13 +22,6 @@ class Plugin {
     }
 
     beforeDeployCreateDeploymentArtifacts() {
-        this.serverless.cli.log('Checking if serverless is managing logs via cloudformation');
-        let cflogsEnabled = this.serverless.service.provider.cfLogs;
-
-        if (!cflogsEnabled) {
-            throw new Error('To use serverless-plugin-cloudwatch-sumologic you must have cfLogs set to true in the serverless.yml file. See https://serverless.com/framework/docs/providers/aws/guide/functions/#log-group-resources for more information.')
-        }
-
         if (!!this.serverless.service.custom.shipLogs.arn) {
             //use existing specified handler ARN
             return;
@@ -49,12 +42,18 @@ class Plugin {
 
         let handlerFunction = templateFile.replace('%collectorUrl%', collectorUrl);
 
+        let customRole = this.serverless.service.custom.shipLogs.role;
+
         fs.writeFileSync(path.join(functionPath, 'handler.js'), handlerFunction);
 
         this.serverless.service.functions.sumologicShipping = {
             handler: 'sumologic-shipping-function/handler.handler',
             events: []
         };
+
+        if (!!customRole) {
+            this.serverless.service.functions.sumologicShipping.role = customRole
+        }
     }
 
     deployCompileEvents() {


### PR DESCRIPTION
This removes the requirement to specify cfLogs (which is no longer necessary in newer version of serverless).

It also allows one to apply a custom IAM role to the created function, so that the function's access can be scoped down.