### PR TITLE
Allow for any customization of function.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,9 @@ custom:
 
         # Optional, default pattern is "[timestamp=*Z, request_id=\"*-*\", event]"
         filterPattern: "[timestamp=*Z, request_id=\"*-*\", correlation_id=\"*-*\", event]"
-        role: ARN of IAM role to use
+        # Optional
+        function:
+            # Can override any handler paramters
 ```
 
 # How it works

--- a/src/index.js
+++ b/src/index.js
@@ -11,6 +11,7 @@ class Plugin {
         this.provider = this.serverless.getProvider('aws');
 
         this.hooks = {
+            'before:deploy:setupProviderConfiguration': this.beforeDeploySetupProviderConfiguration.bind(this),
             'before:deploy:createDeploymentArtifacts': this.beforeDeployCreateDeploymentArtifacts.bind(this),
             'deploy:compileEvents': this.deployCompileEvents.bind(this),
             'after:deploy:deploy': this.afterDeployDeploy.bind(this)
@@ -19,6 +20,21 @@ class Plugin {
 
     getEnvFilePath() {
         return path.join(this.serverless.config.servicePath, 'sumologic-shipping-function');
+    }
+
+    beforeDeploySetupProviderConfiguration() {
+        if (!!this.serverless.service.custom.shipLogs.arn) {
+            //use existing specified handler ARN
+            return;
+        }
+
+        // The function must exist before we set up the provider,
+        // so that the created log group can be depended on appropriately
+        this.serverless.service.functions.sumologicShipping = {
+            handler: 'sumologic-shipping-function/handler.handler',
+            events: [],
+            name: 'sumologicShipping'
+        };
     }
 
     beforeDeployCreateDeploymentArtifacts() {
@@ -45,11 +61,6 @@ class Plugin {
         let customRole = this.serverless.service.custom.shipLogs.role;
 
         fs.writeFileSync(path.join(functionPath, 'handler.js'), handlerFunction);
-
-        this.serverless.service.functions.sumologicShipping = {
-            handler: 'sumologic-shipping-function/handler.handler',
-            events: []
-        };
 
         if (!!customRole) {
             this.serverless.service.functions.sumologicShipping.role = customRole

--- a/src/index.js
+++ b/src/index.js
@@ -30,11 +30,16 @@ class Plugin {
 
         // The function must exist before we set up the provider,
         // so that the created log group can be depended on appropriately
+        let functionExtension = this.serverless.service.custom.shipLogs.function || {}
+        const functionName = functionExtension.name || 'sumologicShipping'
+
         this.serverless.service.functions.sumologicShipping = {
             handler: 'sumologic-shipping-function/handler.handler',
             events: [],
-            name: 'sumologicShipping'
+            name: functionName
         };
+
+        _.merge(this.serverless.service.functions.sumologicShipping, functionExtension)
     }
 
     beforeDeployCreateDeploymentArtifacts() {
@@ -58,13 +63,10 @@ class Plugin {
 
         let handlerFunction = templateFile.replace('%collectorUrl%', collectorUrl);
 
-        let customRole = this.serverless.service.custom.shipLogs.role;
-
         fs.writeFileSync(path.join(functionPath, 'handler.js'), handlerFunction);
 
-        if (!!customRole) {
-            this.serverless.service.functions.sumologicShipping.role = customRole
-        }
+
+
     }
 
     deployCompileEvents() {


### PR DESCRIPTION
In #9, I allowed for customization of the role only. After playing around with our stack some more, I decided it would be nice to be able to modify other pieces of the function definition - namely name, description, and memorySize. I redid this functionality in a way that should be forwards-compatible with any new function definition enhancements Serverless provides in the future.

This is a **breaking change**, as I removed customRole.

Tested against Serverless 1.9.0 and 1.10.0